### PR TITLE
Fixed role based access spelling mistake

### DIFF
--- a/Controllers/ClientAccountController.cs
+++ b/Controllers/ClientAccountController.cs
@@ -107,7 +107,7 @@ namespace Service_Billing.Controllers
             if (team == null)
                 team = new ClientTeam();
             // check if user ought to be able to view this record
-            if(!User.IsInRole("GDXBillingService.Owner"))
+            if(!User.IsInRole("GDXBillingService.FinancialOfficer"))
             {
                 string userLastName = GetUserLastName();
                 if(!String.IsNullOrEmpty(userLastName))

--- a/Models/Repositories/BillRepository.cs
+++ b/Models/Repositories/BillRepository.cs
@@ -236,6 +236,7 @@ namespace Service_Billing.Models.Repositories
                 {
                     bills.Add(GetBill(key));
                 }
+
                 return bills;
                 //IEnumerable<Bill> previousQuarterBills = _billingContext.Bills.Where(b => previousQuarterChargeIds.Keys.Contains(b.Id));
                 


### PR DESCRIPTION
I made a stupid mistake on some role based access stuff that I need to fix. Specifically no one, including admins, could view client details unless a contact. 